### PR TITLE
feat: improve quick switcher overlay positioning

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -65,7 +65,11 @@ var WorkspacePlusPlus = /** @class */ (function (_super) {
                     return;
                 }
                 if (self.data.statusBarQuickSwitcher) {
-                    self.openSearchOverlay();
+                    if (self.searchOverlayEl) {
+                        self.hideSearchOverlay();
+                    } else {
+                        self.openSearchOverlay(self.statusBarEl);
+                    }
                 } else {
                     new modals.SessionManagerModal(self.app, self).open();
                 }

--- a/src/plugin/default-data.js
+++ b/src/plugin/default-data.js
@@ -11,4 +11,5 @@ module.exports = {
     autoSaveOnSwitch: true,
     warnOnUnsavedSwitch: true,
     statusBarQuickSwitcher: false,
+    searchOverlayPosition: null,
 };

--- a/src/plugin/methods/overlays.js
+++ b/src/plugin/methods/overlays.js
@@ -15,7 +15,7 @@ function attachOverlayMethods(WorkspacePlusPlus) {
         });
     };
 
-    WorkspacePlusPlus.prototype.openSearchOverlay = function () {
+    WorkspacePlusPlus.prototype.openSearchOverlay = function (anchorEl) {
         var L = i18n.L;
         var self = this;
         var ordered = this.getOrderedSessions();
@@ -426,6 +426,8 @@ function attachOverlayMethods(WorkspacePlusPlus) {
             if (!self.searchOverlayEl) return;
             // Don't close if a modal (rename/confirm) is open
             if (document.querySelector('.modal-container')) return;
+            // Let status bar handle its own toggle
+            if (self.statusBarEl && self.statusBarEl.contains(e.target)) return;
             if (!self.searchOverlayEl.contains(e.target)) {
                 self.hideSearchOverlay();
             }
@@ -438,6 +440,125 @@ function attachOverlayMethods(WorkspacePlusPlus) {
         document.body.appendChild(overlay);
         this.searchOverlayEl = overlay;
         renderList();
+
+        // Position overlay relative to anchor (status bar button)
+        var margin = 8;
+
+        var STATUS_BAR_FALLBACK_HEIGHT = 28;
+        var MIN_VISIBLE_HEIGHT = 20;
+
+        function cacheStatusBarMetrics() {
+            var aEl = anchorEl || self.statusBarEl;
+            var statusBar = aEl ? aEl.closest('.status-bar') : document.querySelector('.status-bar');
+            if (statusBar) {
+                var h = statusBar.getBoundingClientRect().height;
+                if (h >= MIN_VISIBLE_HEIGHT) {
+                    self._cachedBarHeight = h;
+                }
+            }
+            if (aEl) {
+                var aRect = aEl.getBoundingClientRect();
+                if (aRect.width > 0 && aRect.height > 0) {
+                    self._cachedAnchorCenterX = aRect.left + aRect.width / 2;
+                }
+            }
+        }
+
+        // Cache now while bar may be visible
+        cacheStatusBarMetrics();
+
+        function positionToAnchor() {
+            var oRect = overlay.getBoundingClientRect();
+            var barHeight = self._cachedBarHeight || STATUS_BAR_FALLBACK_HEIGHT;
+
+            // Horizontal: use cached anchor center, or viewport center
+            var centerX = self._cachedAnchorCenterX || window.innerWidth / 2;
+            var lp = centerX - oRect.width / 2;
+            lp = Math.max(margin, Math.min(lp, window.innerWidth - oRect.width - margin));
+
+            // Vertical: always position above status bar area
+            var bp = barHeight + margin;
+            if (bp + oRect.height > window.innerHeight - margin) {
+                bp = margin;
+            }
+
+            overlay.style.right = 'auto';
+            overlay.style.top = 'auto';
+            overlay.style.left = lp + 'px';
+            overlay.style.bottom = bp + 'px';
+        }
+
+        // Position: saved position > anchor-based > CSS default
+        var savedPos = self.data.searchOverlayPosition;
+
+        if (savedPos && savedPos.left != null && savedPos.bottom != null) {
+            var overlayRect = overlay.getBoundingClientRect();
+            var sl = Math.max(margin, Math.min(savedPos.left, window.innerWidth - overlayRect.width - margin));
+            var sb = Math.max(margin, Math.min(savedPos.bottom, window.innerHeight - overlayRect.height - margin));
+            overlay.style.right = 'auto';
+            overlay.style.top = 'auto';
+            overlay.style.left = sl + 'px';
+            overlay.style.bottom = sb + 'px';
+        } else {
+            positionToAnchor();
+        }
+
+        // Double-click on empty area to reset position to anchor default
+        overlay.addEventListener('dblclick', function (e) {
+            if (e.target.closest('.wpp-search-close')) return;
+            if (e.target.closest('.wpp-switch-item')) return;
+            if (e.target.closest('.wpp-search-input')) return;
+            if (e.target.closest('.wpp-qs-action-btn')) return;
+            positionToAnchor();
+            self.data.searchOverlayPosition = null;
+            self.persistData();
+        });
+
+        // Drag to reposition overlay via any empty area
+        overlay.addEventListener('mousedown', function (e) {
+            if (e.target.closest('.wpp-search-close')) return;
+            if (e.target.closest('.wpp-switch-item')) return;
+            if (e.target.closest('.wpp-search-input')) return;
+            if (e.target.closest('.wpp-qs-action-btn')) return;
+            if (e.button !== 0) return;
+            e.preventDefault();
+            overlay.classList.add('wpp-dragging');
+
+            var rect = overlay.getBoundingClientRect();
+            var offsetX = e.clientX - rect.left;
+            var offsetY = e.clientY - rect.top;
+
+            function onMove(ev) {
+                var newLeft = ev.clientX - offsetX;
+                var newTop = ev.clientY - offsetY;
+                var oRect = overlay.getBoundingClientRect();
+                newLeft = Math.max(margin, Math.min(newLeft, window.innerWidth - oRect.width - margin));
+                newTop = Math.max(margin, Math.min(newTop, window.innerHeight - oRect.height - margin));
+                var newBottom = window.innerHeight - newTop - oRect.height;
+                overlay.style.right = 'auto';
+                overlay.style.top = 'auto';
+                overlay.style.left = newLeft + 'px';
+                overlay.style.bottom = newBottom + 'px';
+            }
+
+            function onUp() {
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup', onUp);
+                overlay.classList.remove('wpp-dragging');
+
+                // Save position (bottom-based for stable positioning on resize)
+                var finalRect = overlay.getBoundingClientRect();
+                self.data.searchOverlayPosition = {
+                    left: finalRect.left,
+                    bottom: window.innerHeight - finalRect.bottom,
+                };
+                self.persistData();
+            }
+
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup', onUp);
+        });
+
         setTimeout(function () { searchInput.focus(); }, 20);
     };
 

--- a/src/plugin/methods/persistence.js
+++ b/src/plugin/methods/persistence.js
@@ -24,6 +24,7 @@ var SETTINGS_KEYS = [
     'autoSaveOnSwitch',
     'warnOnUnsavedSwitch',
     'statusBarQuickSwitcher',
+    'searchOverlayPosition',
 ];
 
 function pickKeys(data, keys) {

--- a/styles.css
+++ b/styles.css
@@ -347,11 +347,26 @@
     transform: none;
 }
 
+.wpp-search-overlay {
+    cursor: grab;
+}
+
+.wpp-search-overlay.wpp-dragging {
+    cursor: grabbing;
+}
+
+.wpp-search-overlay .wpp-search-input,
+.wpp-search-overlay .wpp-switch-item,
+.wpp-search-overlay .wpp-search-close {
+    cursor: default;
+}
+
 .wpp-search-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
     width: 100%;
+    padding: 4px 0;
 }
 
 .wpp-search-header .wpp-switch-count {


### PR DESCRIPTION
## Summary
- Position overlay above status bar button instead of fixed bottom-right
- Drag-to-reposition with position persistence across sessions
- Double-click empty area to reset position to default
- Toggle open/close on status bar click
- Handle hidden status bar gracefully with cached metrics

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)