### PR TITLE
Change plugin icon to panels-top-left

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,6 @@
     "minAppVersion": "1.11.0",
     "description": "Workspace session manager with a native-feeling UI/UX.",
     "author": "s1m4ne",
-    "isDesktopOnly": false
+    "isDesktopOnly": false,
+    "icon": "panels-top-left"
 }

--- a/src/main.js
+++ b/src/main.js
@@ -42,7 +42,7 @@ var WorkspacePlusPlus = /** @class */ (function (_super) {
             var L = i18n.L;
 
             // Ribbon icon (left sidebar)
-            self.addRibbonIcon('panels-left-bottom', L.ribbonTooltip, function () {
+            self.addRibbonIcon('panels-top-left', L.ribbonTooltip, function () {
                 new modals.SessionManagerModal(self.app, self).open();
             });
 

--- a/src/plugin/methods/sessions.js
+++ b/src/plugin/methods/sessions.js
@@ -404,7 +404,7 @@ function attachSessionMethods(WorkspacePlusPlus) {
         var session = this.getActiveSession();
         this.statusBarEl.empty();
         var icon = this.statusBarEl.createSpan({ cls: 'wpp-status-icon' });
-        obsidian.setIcon(icon, 'panels-left-bottom');
+        obsidian.setIcon(icon, 'panels-top-left');
 
         // Show group name if a group is active
         var activeGroup = this.getActiveGroup();


### PR DESCRIPTION
## Summary
- Add `icon` field to `manifest.json` with `panels-top-left`
- Update ribbon icon and status bar icon from `panels-left-bottom` to `panels-top-left`

Note: #32 remains open as the installed plugins list does not currently support displaying plugin icons via manifest.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)