### PR TITLE
Normalize initial group assignment for viewed-group session creation

### DIFF
--- a/src/plugin/methods/sessions-validation.js
+++ b/src/plugin/methods/sessions-validation.js
@@ -88,7 +88,9 @@ function attachSessionValidationMethods(WorkspacePlusPlus) {
 
             var createdSessionId = result.sessionId;
             if (targetGroupId && targetGroupId !== beforeActiveGroupId) {
-                return self.addSessionToGroup(createdSessionId, targetGroupId).then(function () {
+                // When creating from a different viewed group, keep membership exclusive
+                // so the new session doesn't remain in the previously active group.
+                return self.moveSessionToGroupExclusive(createdSessionId, targetGroupId).then(function () {
                     return self.resolveGroupSelection(targetGroupId).then(function (selection) {
                         result.viewGroupId = selection.resolvedGroupId || null;
                         return result;


### PR DESCRIPTION
## Summary
- make viewed-group session creation assign group membership exclusively when target group differs from active group
- prevent unintended multi-group membership on creation flow

Fixes #41