### PR TITLE
Deduplicate session list actions between modal and overlay

### DIFF
--- a/src/modals/session-manager-modal.js
+++ b/src/modals/session-manager-modal.js
@@ -3,12 +3,12 @@
 var obsidian = require('obsidian');
 var i18n = require('../i18n');
 var ConfirmModal = require('./confirm-modal');
-var RenameModal = require('./rename-modal');
 var HistoryModal = require('./history-modal');
 var formatRelativeTime = require('./format-relative-time');
 var groupTabUi = require('../group-tab-ui');
 var utils = require('../utils');
 var sessionContextMenu = require('../session-context-menu');
+var sessionListActions = require('../session-list-actions');
 
 // ============================================================
 // Session Manager Modal
@@ -802,16 +802,15 @@ var SessionManagerModal = /** @class */ (function (_super) {
     };
 
     SessionManagerModal.prototype.onRename = function (session) {
-        var L = i18n.L;
         var self = this;
-        new RenameModal(this.app, session.name, function (newName) {
-            self.plugin.renameSessionById(session.id, newName).then(function (renamed) {
-                if (!renamed) return;
+        sessionListActions.renameSessionWithPrompt({
+            app: this.app,
+            plugin: this.plugin,
+            session: session,
+            onRenamed: function () {
                 self.renderList();
-            });
-        }, {
-            emptyNotice: L.emptyName,
-        }).open();
+            },
+        });
     };
 
     SessionManagerModal.prototype.onDelete = function (session) {
@@ -821,14 +820,17 @@ var SessionManagerModal = /** @class */ (function (_super) {
         var message = isActive
             ? L.confirmDeleteActive(session.name)
             : L.confirmDelete(session.name);
-
-        new ConfirmModal(this.app, message, function () {
-            return self.plugin.deleteSession(session.id).then(function (deleted) {
-                if (!deleted) return;
+        return sessionListActions.deleteSessionWithPrompt({
+            app: this.app,
+            plugin: this.plugin,
+            session: session,
+            isActive: isActive,
+            confirmMessage: message,
+            forceConfirm: true,
+            onDeleted: function () {
                 self.renderList();
-                new obsidian.Notice(L.deleted(session.name));
-            });
-        }).open();
+            },
+        });
     };
 
     // --- Focus & selection helpers ---

--- a/src/plugin/methods/overlays.js
+++ b/src/plugin/methods/overlays.js
@@ -7,6 +7,7 @@ var formatRelativeTime = require('../../modals/format-relative-time');
 var groupTabUi = require('../../group-tab-ui');
 var utils = require('../../utils');
 var sessionContextMenu = require('../../session-context-menu');
+var sessionListActions = require('../../session-list-actions');
 
 function hasBlockingModal() {
     return !!document.querySelector('.modal-container');
@@ -540,14 +541,14 @@ function attachOverlayMethods(WorkspacePlusPlus) {
                                 switchSelected();
                             },
                             onRename: function () {
-                                new modals.RenameModal(self.app, sess.name, function (newName) {
-                                    self.renameSessionById(sess.id, newName).then(function (renamed) {
-                                        if (!renamed) return;
+                                sessionListActions.renameSessionWithPrompt({
+                                    app: self.app,
+                                    plugin: self,
+                                    session: sess,
+                                    onRenamed: function () {
                                         refreshOrderedSessions();
-                                    });
-                                }, {
-                                    emptyNotice: L.emptyName,
-                                }).open();
+                                    },
+                                });
                             },
                             onDuplicate: function () {
                                 self.duplicateSession(sess.id).then(function () {
@@ -565,18 +566,16 @@ function attachOverlayMethods(WorkspacePlusPlus) {
                                 });
                             },
                             onDelete: function () {
-                                var doDelete = function () {
-                                    self.deleteSession(sess.id).then(function (deleted) {
-                                        if (!deleted) return;
-                                        new obsidian.Notice(L.deleted(sess.name));
+                                sessionListActions.deleteSessionWithPrompt({
+                                    app: self.app,
+                                    plugin: self,
+                                    session: sess,
+                                    isActive: _isActive,
+                                    confirmMessage: L.confirmDeleteActive(sess.name),
+                                    onDeleted: function () {
                                         refreshOrderedSessions();
-                                    });
-                                };
-                                if (self.data.confirmDeleteByHotkey !== false) {
-                                    new modals.ConfirmModal(self.app, L.confirmDeleteActive(sess.name), doDelete).open();
-                                } else {
-                                    doDelete();
-                                }
+                                    },
+                                });
                             },
                             onVersionHistory: function () {
                                 new modals.HistoryModal(self.app, self, sess).open();
@@ -605,37 +604,29 @@ function attachOverlayMethods(WorkspacePlusPlus) {
                     // Rename
                     renameIcon.addEventListener('click', function (e) {
                         e.stopPropagation();
-                        new modals.RenameModal(self.app, sess.name, function (newName) {
-                            self.renameSessionById(sess.id, newName).then(function (renamed) {
-                                if (!renamed) return;
+                        sessionListActions.renameSessionWithPrompt({
+                            app: self.app,
+                            plugin: self,
+                            session: sess,
+                            onRenamed: function () {
                                 refreshOrderedSessions();
-                            });
-                        }, {
-                            emptyNotice: L.emptyName,
-                        }).open();
+                            },
+                        });
                     });
 
                     // Delete
                     deleteIcon.addEventListener('click', function (e) {
                         e.stopPropagation();
-                        if (Object.keys(self.data.sessions).length <= 1) {
-                            new obsidian.Notice(L.cannotDeleteLast);
-                            return;
-                        }
-
-                        var doDelete = function () {
-                            self.deleteSession(sess.id).then(function (deleted) {
-                                if (!deleted) return;
-                                new obsidian.Notice(L.deleted(sess.name));
+                        sessionListActions.deleteSessionWithPrompt({
+                            app: self.app,
+                            plugin: self,
+                            session: sess,
+                            isActive: _isActive,
+                            confirmMessage: L.confirmDeleteActive(sess.name),
+                            onDeleted: function () {
                                 refreshOrderedSessions();
-                            });
-                        };
-
-                        if (self.data.confirmDeleteByHotkey !== false) {
-                            new modals.ConfirmModal(self.app, L.confirmDeleteActive(sess.name), doDelete).open();
-                        } else {
-                            doDelete();
-                        }
+                            },
+                        });
                     });
                 })(i, session, item, saveIcon, reloadIcon, isActive);
 

--- a/src/session-list-actions.js
+++ b/src/session-list-actions.js
@@ -1,0 +1,90 @@
+'use strict';
+
+var obsidian = require('obsidian');
+var i18n = require('./i18n');
+var ConfirmModal = require('./modals/confirm-modal');
+var RenameModal = require('./modals/rename-modal');
+
+function resolveApp(options) {
+    if (options.app) return options.app;
+    if (options.plugin && options.plugin.app) return options.plugin.app;
+    return null;
+}
+
+function renameSessionWithPrompt(options) {
+    var L = i18n.L;
+    options = options || {};
+    var app = resolveApp(options);
+    var plugin = options.plugin;
+    var session = options.session;
+    if (!app || !plugin || !session) return;
+
+    var modalOptions = Object.assign({
+        emptyNotice: L.emptyName,
+    }, options.modalOptions || {});
+
+    new RenameModal(app, session.name, function (newName) {
+        plugin.renameSessionById(session.id, newName).then(function (renamed) {
+            if (!renamed) return;
+            if (typeof options.onRenamed === 'function') {
+                options.onRenamed(session, newName);
+            }
+        });
+    }, modalOptions).open();
+}
+
+function getDeleteConfirmMessage(session, options) {
+    var L = i18n.L;
+    if (options && options.confirmMessage) return options.confirmMessage;
+    var isActive = !!(options && options.isActive);
+    return isActive
+        ? L.confirmDeleteActive(session.name)
+        : L.confirmDelete(session.name);
+}
+
+function deleteSessionWithPrompt(options) {
+    var L = i18n.L;
+    options = options || {};
+    var app = resolveApp(options);
+    var plugin = options.plugin;
+    var session = options.session;
+    if (!app || !plugin || !session) return Promise.resolve(false);
+
+    if (Object.keys(plugin.data.sessions || {}).length <= 1) {
+        if (options.notifyCannotDelete !== false) {
+            new obsidian.Notice(L.cannotDeleteLast);
+        }
+        return Promise.resolve(false);
+    }
+
+    var doDelete = function () {
+        return plugin.deleteSession(session.id).then(function (deleted) {
+            if (!deleted) return false;
+            if (options.notifyDeleted !== false) {
+                new obsidian.Notice(L.deleted(session.name));
+            }
+            if (typeof options.onDeleted === 'function') {
+                options.onDeleted(session);
+            }
+            return true;
+        });
+    };
+
+    var shouldConfirm = !!options.forceConfirm || plugin.data.confirmDeleteByHotkey !== false;
+    if (shouldConfirm) {
+        new ConfirmModal(
+            app,
+            getDeleteConfirmMessage(session, options),
+            doDelete,
+            options.confirmOptions || {}
+        ).open();
+        return Promise.resolve(true);
+    }
+
+    return doDelete();
+}
+
+module.exports = {
+    renameSessionWithPrompt: renameSessionWithPrompt,
+    deleteSessionWithPrompt: deleteSessionWithPrompt,
+};


### PR DESCRIPTION
## Summary
- extract shared session list actions into a dedicated helper module
- route rename/delete flows in Session Manager modal through shared helper
- route rename/delete flows in search overlay through shared helper
- keep existing delete confirmation behavior in overlay intact

Fixes #40