### PR TITLE
Refactor group-tab UI wiring to reduce duplication

### DIFF
--- a/src/group-tab-ui.js
+++ b/src/group-tab-ui.js
@@ -113,6 +113,110 @@ function attachGroupTabDrag(tabEl, tabsContainerEl, options) {
     });
 }
 
+function renderGroupTabs(options) {
+    var L = i18n.L;
+    options = options || {};
+    var plugin = options.plugin;
+    var containerEl = options.containerEl;
+    if (!plugin || !containerEl) return;
+
+    while (containerEl.firstChild) containerEl.removeChild(containerEl.firstChild);
+
+    var app = options.app || plugin.app;
+    var groups = options.groups || plugin.data.groups || {};
+    var groupOrder = options.groupOrder || plugin.getOrderedGroupTabIds();
+    var selectedGroupId = options.selectedGroupId || null;
+
+    function setupGroupTabDrag(tabEl) {
+        if (!options.onGroupOrderCommit) return;
+        attachGroupTabDrag(tabEl, containerEl, {
+            stopPropagationOnMouseDown: !!options.stopPropagationOnMouseDown,
+            onCommit: function (newOrder) {
+                options.onGroupOrderCommit(newOrder);
+            },
+        });
+    }
+
+    for (var gi = 0; gi < groupOrder.length; gi++) {
+        var gid = groupOrder[gi];
+
+        if (gid === '__all__') {
+            var allTab = document.createElement('div');
+            allTab.className = 'wpp-group-tab';
+            allTab.dataset.groupId = '__all__';
+            if (!selectedGroupId) allTab.classList.add('is-active');
+            allTab.textContent = L.groupAll;
+            allTab.addEventListener('click', function () {
+                if (typeof options.onSelectGroup === 'function') {
+                    options.onSelectGroup(null);
+                }
+            });
+            allTab.addEventListener('contextmenu', function (e) {
+                e.preventDefault();
+                openAllGroupsTabContextMenu({
+                    app: app,
+                    plugin: plugin,
+                    event: e,
+                    onResetViewGroup: options.onResetViewGroup,
+                    onGroupsChanged: options.onGroupsChanged,
+                    onSessionsChanged: options.onSessionsChanged,
+                });
+            });
+            setupGroupTabDrag(allTab);
+            containerEl.appendChild(allTab);
+            continue;
+        }
+
+        var group = groups[gid];
+        if (!group) continue;
+
+        (function (currentGroup) {
+            var tab = document.createElement('div');
+            tab.className = 'wpp-group-tab';
+            tab.dataset.groupId = currentGroup.id;
+            if (selectedGroupId === currentGroup.id) tab.classList.add('is-active');
+            tab.textContent = currentGroup.name;
+            tab.addEventListener('click', function () {
+                if (typeof options.onSelectGroup === 'function') {
+                    options.onSelectGroup(currentGroup.id);
+                }
+            });
+            tab.addEventListener('contextmenu', function (e) {
+                e.preventDefault();
+                openGroupTabContextMenu({
+                    app: app,
+                    plugin: plugin,
+                    event: e,
+                    group: currentGroup,
+                    onDeleteGroup: options.onDeleteGroup,
+                    onGroupsChanged: options.onGroupsChanged,
+                    onSessionsChanged: options.onSessionsChanged,
+                });
+            });
+            setupGroupTabDrag(tab);
+            containerEl.appendChild(tab);
+        })(group);
+    }
+
+    var addBtn = document.createElement('div');
+    addBtn.className = 'wpp-group-add-btn';
+    obsidian.setIcon(addBtn, 'plus');
+    if (options.addButtonTooltip) {
+        obsidian.setTooltip(addBtn, options.addButtonTooltip, {
+            placement: options.addButtonTooltipPlacement || 'bottom',
+            delay: options.addButtonTooltipDelay || 0,
+        });
+    }
+    addBtn.addEventListener('click', function () {
+        if (typeof options.onAddGroupClick === 'function') {
+            options.onAddGroupClick();
+            return;
+        }
+        openCreateGroupPrompt(app, plugin, options.onGroupsChanged);
+    });
+    containerEl.appendChild(addBtn);
+}
+
 function openAllGroupsTabContextMenu(options) {
     var L = i18n.L;
     options = options || {};
@@ -258,4 +362,5 @@ module.exports = {
     openAllGroupsTabContextMenu: openAllGroupsTabContextMenu,
     openCreateGroupPrompt: openCreateGroupPrompt,
     openGroupTabContextMenu: openGroupTabContextMenu,
+    renderGroupTabs: renderGroupTabs,
 };

--- a/src/modals/session-manager-modal.js
+++ b/src/modals/session-manager-modal.js
@@ -909,100 +909,39 @@ var SessionManagerModal = /** @class */ (function (_super) {
         var selectedGroupId = this.getModalGroupId();
 
         var groupOrder = this.plugin.getOrderedGroupTabIds();
-
-        // --- Group tab D&D helper ---
-        function setupGroupTabDrag(tabEl) {
-            groupTabUi.attachGroupTabDrag(tabEl, el, {
-                onCommit: function (newOrder) {
-                    self.plugin.setGroupTabOrder(newOrder);
-                },
-            });
-        }
-
-        // Render tabs in groupOrder
-        for (var gi = 0; gi < groupOrder.length; gi++) {
-            var gid = groupOrder[gi];
-
-            if (gid === '__all__') {
-                // "All" tab
-                var allTab = el.createDiv({ cls: 'wpp-group-tab' });
-                if (!selectedGroupId) allTab.classList.add('is-active');
-                allTab.textContent = L.groupAll;
-                allTab.dataset.groupId = '__all__';
-                allTab.addEventListener('click', function () {
-                    self.selectGroup(null);
-                });
-
-                // "All" tab right-click context menu
-                allTab.addEventListener('contextmenu', function (e) {
-                    e.preventDefault();
-                    groupTabUi.openAllGroupsTabContextMenu({
-                        app: self.app,
-                        plugin: self.plugin,
-                        event: e,
-                        onResetViewGroup: function () {
-                            self.modalGroupId = null;
-                        },
-                        onGroupsChanged: function () {
-                            self.renderGroupTabs();
-                        },
-                        onSessionsChanged: function () {
-                            self.renderList();
-                        },
-                    });
-                });
-
-                setupGroupTabDrag(allTab);
-
-            } else if (groups[gid]) {
-                // Group tab
-                (function (group) {
-                    var tab = el.createDiv({ cls: 'wpp-group-tab' });
-                    if (selectedGroupId === group.id) tab.classList.add('is-active');
-                    tab.textContent = group.name;
-                    tab.dataset.groupId = group.id;
-                    tab.addEventListener('click', function () {
-                        self.selectGroup(group.id);
-                    });
-                    // Right-click context menu
-                    tab.addEventListener('contextmenu', function (e) {
-                        e.preventDefault();
-                        groupTabUi.openGroupTabContextMenu({
-                            app: self.app,
-                            plugin: self.plugin,
-                            event: e,
-                            group: group,
-                            onDeleteGroup: function (deletedGroupId) {
-                                if (self.modalGroupId === deletedGroupId) {
-                                    self.modalGroupId = self.plugin.data.activeGroupId || null;
-                                }
-                            },
-                            onGroupsChanged: function () {
-                                self.renderGroupTabs();
-                            },
-                            onSessionsChanged: function () {
-                                self.renderList();
-                            },
-                        });
-                    });
-
-                    setupGroupTabDrag(tab);
-                })(groups[gid]);
-            }
-        }
-
-        // "+" add group button
-        var addBtn = el.createDiv({ cls: 'wpp-group-add-btn' });
-        obsidian.setIcon(addBtn, 'plus');
-        obsidian.setTooltip(addBtn, L.groupCreateNew, {
-            placement: 'bottom',
-            delay: 0,
-        });
-
-        addBtn.addEventListener('click', function () {
-            groupTabUi.openCreateGroupPrompt(self.app, self.plugin, function () {
+        groupTabUi.renderGroupTabs({
+            app: this.app,
+            plugin: this.plugin,
+            containerEl: el,
+            groups: groups,
+            groupOrder: groupOrder,
+            selectedGroupId: selectedGroupId,
+            onSelectGroup: function (groupId) {
+                self.selectGroup(groupId);
+            },
+            onResetViewGroup: function () {
+                self.modalGroupId = null;
+            },
+            onDeleteGroup: function (deletedGroupId) {
+                if (self.modalGroupId === deletedGroupId) {
+                    self.modalGroupId = self.plugin.data.activeGroupId || null;
+                }
+            },
+            onGroupsChanged: function () {
                 self.renderGroupTabs();
-            });
+            },
+            onSessionsChanged: function () {
+                self.renderList();
+            },
+            onGroupOrderCommit: function (newOrder) {
+                self.plugin.setGroupTabOrder(newOrder);
+            },
+            addButtonTooltip: L.groupCreateNew,
+            onAddGroupClick: function () {
+                groupTabUi.openCreateGroupPrompt(self.app, self.plugin, function () {
+                    self.renderGroupTabs();
+                });
+            },
         });
     };
 

--- a/src/plugin/methods/overlays.js
+++ b/src/plugin/methods/overlays.js
@@ -280,104 +280,43 @@ function attachOverlayMethods(WorkspacePlusPlus) {
                 : L.searchOverlayHelp;
 
             var groupOrder = self.getOrderedGroupTabIds();
-
-            // Group tab D&D helper
-            function setupGroupTabDrag(tabEl) {
-                groupTabUi.attachGroupTabDrag(tabEl, groupTabsRow, {
-                    stopPropagationOnMouseDown: true,
-                    onCommit: function (newOrder) {
-                        self.setGroupTabOrder(newOrder);
-                    },
-                });
-            }
-
-            // Render tabs in groupOrder
-            for (var gi = 0; gi < groupOrder.length; gi++) {
-                var gid = groupOrder[gi];
-
-                if (gid === '__all__') {
-                    var allTab = document.createElement('div');
-                    allTab.className = 'wpp-group-tab';
-                    allTab.dataset.groupId = '__all__';
-                    if (!getOverlayGroupId()) allTab.classList.add('is-active');
-                    allTab.textContent = L.groupAll;
-                    allTab.addEventListener('click', function () {
-                        applyOverlayGroupSelection(null);
-                    });
-
-                    // "All" tab right-click context menu
-                    allTab.addEventListener('contextmenu', function (e) {
-                        e.preventDefault();
-                        groupTabUi.openAllGroupsTabContextMenu({
-                            app: self.app,
-                            plugin: self,
-                            event: e,
-                            onResetViewGroup: function () {
-                                overlayGroupId = null;
-                                self.searchOverlayViewGroupId = null;
-                            },
-                            onGroupsChanged: function () {
-                                renderGroupTabs();
-                            },
-                            onSessionsChanged: function () {
-                                refreshOrderedSessions();
-                            },
-                        });
-                    });
-
-                    setupGroupTabDrag(allTab);
-                    groupTabsRow.appendChild(allTab);
-                } else if (groups[gid]) {
-                    (function (group) {
-                        var tab = document.createElement('div');
-                        tab.className = 'wpp-group-tab';
-                        tab.dataset.groupId = group.id;
-                        if (getOverlayGroupId() === group.id) tab.classList.add('is-active');
-                        tab.textContent = group.name;
-                        tab.addEventListener('click', function () {
-                            applyOverlayGroupSelection(group.id);
-                        });
-
-                        // Group tab right-click context menu
-                        tab.addEventListener('contextmenu', function (e) {
-                            e.preventDefault();
-                            groupTabUi.openGroupTabContextMenu({
-                                app: self.app,
-                                plugin: self,
-                                event: e,
-                                group: group,
-                                onDeleteGroup: function (deletedGroupId) {
-                                    if (overlayGroupId === deletedGroupId) {
-                                        overlayGroupId = self.data.activeGroupId || null;
-                                        self.searchOverlayViewGroupId = overlayGroupId || null;
-                                    }
-                                },
-                                onGroupsChanged: function () {
-                                    renderGroupTabs();
-                                },
-                                onSessionsChanged: function () {
-                                    refreshOrderedSessions();
-                                },
-                            });
-                        });
-
-                        setupGroupTabDrag(tab);
-                        groupTabsRow.appendChild(tab);
-                    })(groups[gid]);
-                }
-            }
-
-            // "+" add group button
-            var addBtn = document.createElement('div');
-            addBtn.className = 'wpp-group-add-btn';
-            obsidian.setIcon(addBtn, 'plus');
-            addBtn.addEventListener('click', function () {
-                groupTabUi.openCreateGroupPrompt(self.app, self, function () {
+            groupTabUi.renderGroupTabs({
+                app: self.app,
+                plugin: self,
+                containerEl: groupTabsRow,
+                groups: groups,
+                groupOrder: groupOrder,
+                selectedGroupId: getOverlayGroupId(),
+                stopPropagationOnMouseDown: true,
+                onSelectGroup: function (groupId) {
+                    applyOverlayGroupSelection(groupId);
+                },
+                onResetViewGroup: function () {
+                    overlayGroupId = null;
+                    self.searchOverlayViewGroupId = null;
+                },
+                onDeleteGroup: function (deletedGroupId) {
+                    if (overlayGroupId === deletedGroupId) {
+                        overlayGroupId = self.data.activeGroupId || null;
+                        self.searchOverlayViewGroupId = overlayGroupId || null;
+                    }
+                },
+                onGroupsChanged: function () {
                     renderGroupTabs();
+                },
+                onSessionsChanged: function () {
                     refreshOrderedSessions();
-                });
+                },
+                onGroupOrderCommit: function (newOrder) {
+                    self.setGroupTabOrder(newOrder);
+                },
+                onAddGroupClick: function () {
+                    groupTabUi.openCreateGroupPrompt(self.app, self, function () {
+                        renderGroupTabs();
+                        refreshOrderedSessions();
+                    });
+                },
             });
-            groupTabsRow.appendChild(addBtn);
         }
 
         overlay.appendChild(groupTabsRow);


### PR DESCRIPTION
## Summary
- add a shared group-tab renderer/binder in group-tab-ui
- switch Session Manager group-tab rendering to shared helper
- switch search overlay group-tab rendering to shared helper
- preserve existing interaction behavior (group switching, context menus, drag reorder, add group)

Refs #38