### PR TITLE
Fix: periodic snapshot timer should only run when auto-save is enabled

### DIFF
--- a/src/plugin/methods/history.js
+++ b/src/plugin/methods/history.js
@@ -198,12 +198,13 @@ function attachHistoryMethods(WorkspacePlusPlus) {
     WorkspacePlusPlus.prototype.startHistorySnapshotTimer = function () {
         this.stopHistorySnapshotTimer();
         if (!this.isVersionHistoryEnabled()) return;
+        if (!this.isAutoSaveOnSwitchEnabled()) return;
 
         var self = this;
         var intervalMs = this.getVersionHistorySnapshotInterval() * 60000;
 
         this._historySnapshotTimer = setInterval(function () {
-            if (!self.isVersionHistoryEnabled()) {
+            if (!self.isVersionHistoryEnabled() || !self.isAutoSaveOnSwitchEnabled()) {
                 self.stopHistorySnapshotTimer();
                 return;
             }

--- a/src/plugin/methods/sessions.js
+++ b/src/plugin/methods/sessions.js
@@ -299,6 +299,14 @@ function attachSessionMethods(WorkspacePlusPlus) {
         options = options || {};
         this.data.autoSaveOnSwitch = !!enabled;
         var isOn = this.isAutoSaveOnSwitchEnabled();
+
+        // Sync snapshot timer — it requires both version history and auto-save
+        if (isOn) {
+            this.startHistorySnapshotTimer();
+        } else {
+            this.stopHistorySnapshotTimer();
+        }
+
         return this.persistData().then(function () {
             if (options.notify) {
                 new obsidian.Notice(isOn ? L.autoSaveEnabled : L.autoSaveDisabled);

--- a/src/settings.js
+++ b/src/settings.js
@@ -342,24 +342,26 @@ var WorkspacePlusPlusSettingTab = /** @class */ (function (_super) {
             vhMasterSetting.settingEl.addClass('wpp-has-nested');
             var vhNestedDiv = vhMasterSetting.settingEl.createDiv({ cls: 'wpp-nested-settings' });
 
-            new obsidian.Setting(vhNestedDiv)
-                .setName(L.settingsVersionHistoryInterval)
-                .setDesc(L.settingsVersionHistoryIntervalDesc)
-                .addDropdown(function (dropdown) {
-                    dropdown.addOption('1', '1');
-                    dropdown.addOption('2', '2');
-                    dropdown.addOption('5', '5');
-                    dropdown.addOption('10', '10');
-                    dropdown.addOption('15', '15');
-                    dropdown.addOption('30', '30');
-                    dropdown.setValue(String(self.plugin.getVersionHistorySnapshotInterval()));
-                    if (!versionHistoryEnabled) dropdown.setDisabled(true);
-                    dropdown.onChange(function (value) {
-                        self.plugin.data.versionHistorySnapshotInterval = parseInt(value, 10);
-                        self.plugin.persistData();
-                        self.plugin.startHistorySnapshotTimer();
+            if (self.plugin.isAutoSaveOnSwitchEnabled()) {
+                new obsidian.Setting(vhNestedDiv)
+                    .setName(L.settingsVersionHistoryInterval)
+                    .setDesc(L.settingsVersionHistoryIntervalDesc)
+                    .addDropdown(function (dropdown) {
+                        dropdown.addOption('1', '1');
+                        dropdown.addOption('2', '2');
+                        dropdown.addOption('5', '5');
+                        dropdown.addOption('10', '10');
+                        dropdown.addOption('15', '15');
+                        dropdown.addOption('30', '30');
+                        dropdown.setValue(String(self.plugin.getVersionHistorySnapshotInterval()));
+                        if (!versionHistoryEnabled) dropdown.setDisabled(true);
+                        dropdown.onChange(function (value) {
+                            self.plugin.data.versionHistorySnapshotInterval = parseInt(value, 10);
+                            self.plugin.persistData();
+                            self.plugin.startHistorySnapshotTimer();
+                        });
                     });
-                });
+            }
 
             addToggleSetting(vhNestedDiv, {
                 name: L.settingsVersionHistoryCtrlRmb,


### PR DESCRIPTION
## Summary
- Snapshot timer now requires both version history AND auto-save to be enabled
- `setAutoSaveOnSwitch()` syncs the snapshot timer on toggle
- Snapshot interval setting is hidden in UI when auto-save is OFF

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)