### PR TITLE
Guard startup layout restoration race

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "workspace-plus-plus",
     "name": "Workspace++",
-    "version": "0.7.8",
+    "version": "0.7.9",
     "minAppVersion": "1.11.0",
     "description": "Workspace session manager with a native-feeling UI/UX.",
     "author": "s1m4ne",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "obsidian-workspace-plus",
-    "version": "0.7.8",
+    "version": "0.7.9",
     "description": "Workspace session manager for Obsidian",
     "main": "main.js",
     "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -55,6 +55,10 @@ var WorkspacePlusPlus = /** @class */ (function (_super) {
             self.isSwitchingSession = false;
             self.pendingSwitchRequest = null;
             self.switchLockAt = 0;
+            self.startupSettleStartedAt = 0;
+            self.startupSettleUntil = 0;
+            self.startupSettleTimer = null;
+            self.startupFlushTimer = null;
             self.syncSessionOrder();
             i18n.resolveLocale(self.data.language);
             var L = i18n.L;
@@ -97,11 +101,16 @@ var WorkspacePlusPlus = /** @class */ (function (_super) {
             self.settingTab = new settings.WorkspacePlusPlusSettingTab(self.app, self);
             self.addSettingTab(self.settingTab);
 
+            self.registerEvent(self.app.workspace.on('layout-change', function () {
+                self.noteStartupLayoutChange();
+            }));
+
             // Startup: ensure default session exists, then flush
             self.app.workspace.onLayoutReady(function () {
+                self.startStartupSettleWindow();
                 self.ensureDefaultSession();
                 self.syncSessionCommands();
-                self.flushOnStartup();
+                self.scheduleStartupFlush();
                 self.startHistorySnapshotTimer();
                 self.initRotationBackupTimestamp();
             });
@@ -114,6 +123,16 @@ var WorkspacePlusPlus = /** @class */ (function (_super) {
         this.hideSearchOverlay();
         this.pendingSwitchRequest = null;
         this.isSwitchingSession = false;
+        this.startupSettleStartedAt = 0;
+        if (this.startupSettleTimer) {
+            clearTimeout(this.startupSettleTimer);
+            this.startupSettleTimer = null;
+        }
+        if (this.startupFlushTimer) {
+            clearTimeout(this.startupFlushTimer);
+            this.startupFlushTimer = null;
+        }
+        this.startupSettleUntil = 0;
         return this.flushPendingPersistence();
     };
 

--- a/src/plugin/methods/sessions.js
+++ b/src/plugin/methods/sessions.js
@@ -6,6 +6,10 @@ var utils = require('../../utils');
 var modals = require('../../modals');
 var attachSessionValidationMethods = require('./sessions-validation');
 
+var STARTUP_SETTLE_MS = 1200;
+var STARTUP_LAYOUT_CHANGE_SETTLE_MS = 400;
+var STARTUP_SETTLE_MAX_MS = 5000;
+
 function attachSessionMethods(WorkspacePlusPlus) {
     attachSessionValidationMethods(WorkspacePlusPlus);
     // --- Session order ---
@@ -539,6 +543,15 @@ function attachSessionMethods(WorkspacePlusPlus) {
         var self = this;
         options = options || {};
 
+        var startupDelayMs = this.getStartupSettleRemainingMs();
+        if (startupDelayMs > 0) {
+            return new Promise(function (resolve) {
+                setTimeout(function () {
+                    self.switchSession(targetId, options).then(resolve);
+                }, startupDelayMs);
+            });
+        }
+
         // Recover from stale switching lock (e.g. interrupted modal flow).
         if (this.isSwitchingSession) {
             var lockAt = this.switchLockAt || 0;
@@ -942,6 +955,84 @@ function attachSessionMethods(WorkspacePlusPlus) {
         this.updateStatusBar();
         this.syncSessionCommands();
         this.persistData();
+    };
+
+    WorkspacePlusPlus.prototype.setStartupSettleDeadline = function (deadlineMs) {
+        var self = this;
+        var nextDeadline = typeof deadlineMs === 'number' ? deadlineMs : 0;
+
+        if (this.startupSettleTimer) {
+            clearTimeout(this.startupSettleTimer);
+            this.startupSettleTimer = null;
+        }
+
+        if (nextDeadline <= Date.now()) {
+            this.startupSettleStartedAt = 0;
+            this.startupSettleUntil = 0;
+            return 0;
+        }
+
+        this.startupSettleUntil = nextDeadline;
+        this.startupSettleTimer = setTimeout(function () {
+            self.startupSettleStartedAt = 0;
+            self.startupSettleUntil = 0;
+            self.startupSettleTimer = null;
+        }, nextDeadline - Date.now());
+        return this.startupSettleUntil;
+    };
+
+    WorkspacePlusPlus.prototype.startStartupSettleWindow = function (durationMs) {
+        var startedAt = Date.now();
+        var duration = typeof durationMs === 'number' && durationMs > 0
+            ? durationMs
+            : STARTUP_SETTLE_MS;
+
+        this.startupSettleStartedAt = startedAt;
+        return this.setStartupSettleDeadline(startedAt + duration);
+    };
+
+    WorkspacePlusPlus.prototype.getStartupSettleRemainingMs = function () {
+        var remaining = (this.startupSettleUntil || 0) - Date.now();
+        return remaining > 0 ? remaining : 0;
+    };
+
+    WorkspacePlusPlus.prototype.isStartupSettling = function () {
+        return this.getStartupSettleRemainingMs() > 0;
+    };
+
+    WorkspacePlusPlus.prototype.noteStartupLayoutChange = function () {
+        if (!this.isStartupSettling()) return;
+
+        var startedAt = this.startupSettleStartedAt || Date.now();
+        var maxDeadline = startedAt + STARTUP_SETTLE_MAX_MS;
+        var nextDeadline = Math.min(maxDeadline, Date.now() + STARTUP_LAYOUT_CHANGE_SETTLE_MS);
+
+        if (nextDeadline <= (this.startupSettleUntil || 0)) return;
+        this.setStartupSettleDeadline(nextDeadline);
+        this.scheduleStartupFlush();
+    };
+
+    WorkspacePlusPlus.prototype.scheduleStartupFlush = function () {
+        var self = this;
+
+        if (this.startupFlushTimer) {
+            clearTimeout(this.startupFlushTimer);
+            this.startupFlushTimer = null;
+        }
+
+        if (!this.isAutoSaveOnSwitchEnabled()) return Promise.resolve(false);
+
+        var delayMs = this.getStartupSettleRemainingMs();
+        if (delayMs <= 0) {
+            return Promise.resolve(this.flushOnStartup());
+        }
+
+        return new Promise(function (resolve) {
+            self.startupFlushTimer = setTimeout(function () {
+                self.startupFlushTimer = null;
+                resolve(self.flushOnStartup());
+            }, delayMs);
+        });
     };
 
     WorkspacePlusPlus.prototype.flushOnStartup = function () {

--- a/tests/regression.test.js
+++ b/tests/regression.test.js
@@ -186,3 +186,52 @@ test('viewed-group session creation uses exclusive group assignment', async func
     assert.equal(addCalled, false);
     assert.equal(result.viewGroupId, 'g2');
 });
+
+test('switchSession waits for startup settle window before switching', async function () {
+    const plugin = createPlugin({
+        activeSessionId: 'a',
+        sessionOrder: ['a', 'b'],
+        sessions: {
+            a: { id: 'a', name: 'A', layout: { layout: 'a' }, modified: 1 },
+            b: { id: 'b', name: 'B', layout: { layout: 'b' }, modified: 1 },
+        },
+    });
+
+    let switchedAt = 0;
+    const startedAt = Date.now();
+
+    plugin.performSessionSwitch = function () {
+        switchedAt = Date.now();
+        return Promise.resolve(true);
+    };
+
+    plugin.startStartupSettleWindow(20);
+    const switched = await plugin.switchSession('b', { silent: true });
+
+    assert.equal(switched, true);
+    assert.ok(switchedAt >= startedAt + 15);
+});
+
+test('scheduleStartupFlush waits until startup settle completes', async function () {
+    const plugin = createPlugin({
+        activeSessionId: 'a',
+        sessionOrder: ['a'],
+        sessions: {
+            a: { id: 'a', name: 'A', layout: { layout: 'a' }, modified: 1 },
+        },
+        autoSaveOnSwitch: true,
+    });
+
+    const calls = [];
+    plugin.flushOnStartup = function () {
+        calls.push(Date.now());
+        return Promise.resolve(true);
+    };
+
+    const startedAt = Date.now();
+    plugin.startStartupSettleWindow(20);
+    await plugin.scheduleStartupFlush();
+
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0] >= startedAt + 15);
+});


### PR DESCRIPTION
## Summary
- delay startup session flush until the workspace layout settles
- postpone session switching during the startup settle window
- add regression coverage for startup settle timing

Closes #68