### PR TITLE
Fix settings not persisted after restart

### DIFF
--- a/src/plugin/methods/persistence.js
+++ b/src/plugin/methods/persistence.js
@@ -45,6 +45,11 @@ var SETTINGS_KEYS = [
     'statusBarScrollCooldownMs',
     'statusBarScrollResetMs',
     'statusBarScrollInvert',
+    'statusBarActions',
+    'confirmQuickActions',
+    'showFilterInput',
+    'showActiveSwitchCommand',
+    'numberedSwitchCommands',
 ];
 
 function pickKeys(data, keys) {


### PR DESCRIPTION
## Summary
- Add missing keys to `SETTINGS_KEYS` in `persistence.js` so they are properly saved and loaded
- Fixes `statusBarActions` (middle-click bindings resetting on restart) — closes #81
- Also fixes 4 other settings with the same issue: `confirmQuickActions`, `showFilterInput`, `showActiveSwitchCommand`, `numberedSwitchCommands`

## Test plan
- [ ] Set middle-click to an action → restart Obsidian → verify it persists
- [ ] Toggle each of the 4 boolean settings to non-default → restart → verify they persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)