### PR TITLE
Fix search filter disappearing for existing users (#84)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -89,11 +89,6 @@ var WorkspacePlusPlus = /** @class */ (function (_super) {
             }
             self.data.statusBarActions = Object.assign({}, DEFAULT_DATA.statusBarActions, self.data.statusBarActions || {});
 
-            // Migrate: existing users keep filter visible (new default is OFF)
-            if (saved && saved.showFilterInput === undefined) {
-                self.data.showFilterInput = true;
-            }
-
             self.normalizeGroupFeatureState();
             self.isSwitchingSession = false;
             self.pendingSwitchRequest = null;

--- a/src/plugin/methods/persistence.js
+++ b/src/plugin/methods/persistence.js
@@ -792,6 +792,7 @@ function attachPersistenceMethods(WorkspacePlusPlus) {
         var self = this;
         var L = i18n.L;
         var loadedMain = null;
+        var rawSaved = null;
         var legacyMain = null;
         var hadLegacyInMain = false;
 
@@ -800,6 +801,7 @@ function attachPersistenceMethods(WorkspacePlusPlus) {
                 return null;
             })
             .then(function (saved) {
+                rawSaved = saved;
                 loadedMain = saved || {};
                 self.globalSettings = Object.assign(
                     {},
@@ -856,6 +858,14 @@ function attachPersistenceMethods(WorkspacePlusPlus) {
                     var effectiveSettings = self.isUsingLocalSettings()
                         ? Object.assign({}, self.globalSettings, localSettings)
                         : Object.assign({}, self.globalSettings);
+                    // Migrate: existing users keep filter visible (new default is OFF).
+                    // rawSaved is null for new installs; for existing users it is the raw
+                    // data.json object. Before showFilterInput was added to SETTINGS_KEYS
+                    // it was never written to disk, so rawSaved.showFilterInput is
+                    // undefined for any user who predates that setting.
+                    if (rawSaved !== null && rawSaved !== undefined && rawSaved.showFilterInput === undefined) {
+                        effectiveSettings.showFilterInput = true;
+                    }
                     var merged = Object.assign({}, self.getDefaultSessionData(), sessionData || {});
                     return Object.assign(merged, effectiveSettings);
                 });


### PR DESCRIPTION
## Summary

- PR #82 added `showFilterInput` to `SETTINGS_KEYS`, which caused `getDefaultSettingsData()` to include `showFilterInput: false` in the merged result of `loadWithBackup()`
- This made the migration check `saved.showFilterInput === undefined` never `true`, so existing users who had the filter visible lost it on restart
- Move the migration into `loadWithBackup()` where the raw `loadData()` result is available before DEFAULT_DATA is merged in

## Behaviour

| User | Before fix | After fix |
|------|-----------|-----------|
| Existing user (filter was always on) | filter disappears on restart | filter stays on ✓ |
| User who explicitly turned filter off | filter disappears on restart | filter stays off ✓ |
| New user | filter off (default) | filter off (default) ✓ |

## Test plan

- [ ] Existing vault with plugin data but no `showFilterInput` saved → filter should be visible after restart
- [ ] User who explicitly set filter to off → filter should remain off after restart
- [ ] Fresh install → filter should be off by default

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)