### PR TITLE
Add workspace-session front-matter property (#87)

### DIFF
--- a/main.js
+++ b/main.js
@@ -472,6 +472,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "No backups available.",
         rotationBackupGeneration: function(count) {
           return count + " session" + (count !== 1 ? "s" : "");
+        },
+        frontmatterSessionNotFound: function(n) {
+          return 'Session "' + n + '" not found (workspace-session)';
+        },
+        frontmatterAlreadyActive: function(n) {
+          return 'Session "' + n + '" is already active';
         }
       },
       zh: {
@@ -796,6 +802,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "\u6CA1\u6709\u53EF\u7528\u7684\u5907\u4EFD\u3002",
         rotationBackupGeneration: function(count) {
           return count + " \u4E2A\u4F1A\u8BDD";
+        },
+        frontmatterSessionNotFound: function(n) {
+          return "\u4F1A\u8BDD\u201C" + n + "\u201D\u672A\u627E\u5230\uFF08workspace-session\uFF09";
+        },
+        frontmatterAlreadyActive: function(n) {
+          return "\u4F1A\u8BDD\u201C" + n + "\u201D\u5DF2\u5904\u4E8E\u6D3B\u52A8\u72B6\u6001";
         }
       },
       "zh-TW": {
@@ -1120,6 +1132,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "\u6C92\u6709\u53EF\u7528\u7684\u5099\u4EFD\u3002",
         rotationBackupGeneration: function(count) {
           return count + " \u500B\u5DE5\u4F5C\u968E\u6BB5";
+        },
+        frontmatterSessionNotFound: function(n) {
+          return "\u5DE5\u4F5C\u968E\u6BB5\u300C" + n + "\u300D\u672A\u627E\u5230\uFF08workspace-session\uFF09";
+        },
+        frontmatterAlreadyActive: function(n) {
+          return "\u5DE5\u4F5C\u968E\u6BB5\u300C" + n + "\u300D\u5DF2\u8655\u65BC\u6D3B\u52D5\u72C0\u614B";
         }
       },
       es: {
@@ -1444,6 +1462,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "No hay copias de seguridad disponibles.",
         rotationBackupGeneration: function(count) {
           return count + " sesi\xF3n" + (count !== 1 ? "es" : "");
+        },
+        frontmatterSessionNotFound: function(n) {
+          return "Sesi\xF3n \xAB" + n + "\xBB no encontrada (workspace-session)";
+        },
+        frontmatterAlreadyActive: function(n) {
+          return "La sesi\xF3n \xAB" + n + "\xBB ya est\xE1 activa";
         }
       },
       fr: {
@@ -1768,6 +1792,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "Aucune sauvegarde disponible.",
         rotationBackupGeneration: function(count) {
           return count + " session" + (count !== 1 ? "s" : "");
+        },
+        frontmatterSessionNotFound: function(n) {
+          return "Session \xAB\xA0" + n + "\xA0\xBB introuvable (workspace-session)";
+        },
+        frontmatterAlreadyActive: function(n) {
+          return "La session \xAB\xA0" + n + "\xA0\xBB est d\xE9j\xE0 active";
         }
       },
       ar: {
@@ -2092,6 +2122,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "\u0644\u0627 \u062A\u0648\u062C\u062F \u0646\u0633\u062E \u0627\u062D\u062A\u064A\u0627\u0637\u064A\u0629 \u0645\u062A\u0627\u062D\u0629.",
         rotationBackupGeneration: function(count) {
           return count + " \u062C\u0644\u0633\u0629";
+        },
+        frontmatterSessionNotFound: function(n) {
+          return "\u0627\u0644\u062C\u0644\u0633\u0629 \u201C" + n + "\u201D \u063A\u064A\u0631 \u0645\u0648\u062C\u0648\u062F\u0629 (workspace-session)";
+        },
+        frontmatterAlreadyActive: function(n) {
+          return "\u0627\u0644\u062C\u0644\u0633\u0629 \u201C" + n + "\u201D \u0646\u0634\u0637\u0629 \u0628\u0627\u0644\u0641\u0639\u0644";
         }
       },
       pt: {
@@ -2416,6 +2452,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "Nenhum backup dispon\xEDvel.",
         rotationBackupGeneration: function(count) {
           return count + " sess\xE3o" + (count !== 1 ? "\xF5es" : "");
+        },
+        frontmatterSessionNotFound: function(n) {
+          return "Sess\xE3o \u201C" + n + "\u201D n\xE3o encontrada (workspace-session)";
+        },
+        frontmatterAlreadyActive: function(n) {
+          return "A sess\xE3o \u201C" + n + "\u201D j\xE1 est\xE1 ativa";
         }
       },
       ru: {
@@ -2740,6 +2782,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "\u041D\u0435\u0442 \u0434\u043E\u0441\u0442\u0443\u043F\u043D\u044B\u0445 \u0440\u0435\u0437\u0435\u0440\u0432\u043D\u044B\u0445 \u043A\u043E\u043F\u0438\u0439.",
         rotationBackupGeneration: function(count) {
           return count + " \u0441\u0435\u0430\u043D\u0441" + (count === 1 ? "" : "\u043E\u0432");
+        },
+        frontmatterSessionNotFound: function(n) {
+          return "\u0421\u0435\u0430\u043D\u0441 \xAB" + n + "\xBB \u043D\u0435 \u043D\u0430\u0439\u0434\u0435\u043D (workspace-session)";
+        },
+        frontmatterAlreadyActive: function(n) {
+          return "\u0421\u0435\u0430\u043D\u0441 \xAB" + n + "\xBB \u0443\u0436\u0435 \u0430\u043A\u0442\u0438\u0432\u0435\u043D";
         }
       },
       de: {
@@ -3064,6 +3112,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "Keine Sicherungen verf\xFCgbar.",
         rotationBackupGeneration: function(count) {
           return count + " Sitzung" + (count !== 1 ? "en" : "");
+        },
+        frontmatterSessionNotFound: function(n) {
+          return "Sitzung \u201E" + n + "\u201C nicht gefunden (workspace-session)";
+        },
+        frontmatterAlreadyActive: function(n) {
+          return "Sitzung \u201E" + n + "\u201C ist bereits aktiv";
         }
       },
       ja: {
@@ -3502,6 +3556,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "\u30D0\u30C3\u30AF\u30A2\u30C3\u30D7\u306F\u3042\u308A\u307E\u305B\u3093\u3002",
         rotationBackupGeneration: function(count) {
           return count + " \u30BB\u30C3\u30B7\u30E7\u30F3";
+        },
+        frontmatterSessionNotFound: function(n) {
+          return "\u30BB\u30C3\u30B7\u30E7\u30F3\u300C" + n + "\u300D\u304C\u898B\u3064\u304B\u308A\u307E\u305B\u3093\uFF08workspace-session\uFF09";
+        },
+        frontmatterAlreadyActive: function(n) {
+          return "\u30BB\u30C3\u30B7\u30E7\u30F3\u300C" + n + "\u300D\u306F\u65E2\u306B\u30A2\u30AF\u30C6\u30A3\u30D6\u3067\u3059";
         }
       },
       ko: {
@@ -3826,6 +3886,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "\uC0AC\uC6A9 \uAC00\uB2A5\uD55C \uBC31\uC5C5\uC774 \uC5C6\uC2B5\uB2C8\uB2E4.",
         rotationBackupGeneration: function(count) {
           return count + "\uAC1C \uC138\uC158";
+        },
+        frontmatterSessionNotFound: function(n) {
+          return "\u201C" + n + "\u201D \uC138\uC158\uC744 \uCC3E\uC744 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4 (workspace-session)";
+        },
+        frontmatterAlreadyActive: function(n) {
+          return "\u201C" + n + "\u201D \uC138\uC158\uC774 \uC774\uBBF8 \uD65C\uC131 \uC0C1\uD0DC\uC785\uB2C8\uB2E4";
         }
       },
       it: {
@@ -4150,6 +4216,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "Nessun backup disponibile.",
         rotationBackupGeneration: function(count) {
           return count + " session" + (count !== 1 ? "i" : "e");
+        },
+        frontmatterSessionNotFound: function(n) {
+          return "Sessione \xAB" + n + "\xBB non trovata (workspace-session)";
+        },
+        frontmatterAlreadyActive: function(n) {
+          return "La sessione \xAB" + n + "\xBB \xE8 gi\xE0 attiva";
         }
       },
       tr: {
@@ -4474,6 +4546,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "Kullan\u0131labilir yedek yok.",
         rotationBackupGeneration: function(count) {
           return count + " oturum";
+        },
+        frontmatterSessionNotFound: function(n) {
+          return "\u201C" + n + "\u201D oturumu bulunamad\u0131 (workspace-session)";
+        },
+        frontmatterAlreadyActive: function(n) {
+          return "\u201C" + n + "\u201D oturumu zaten aktif";
         }
       },
       id: {
@@ -4798,6 +4876,12 @@ var require_i18n = __commonJS({
         rotationBackupNone: "Tidak ada cadangan tersedia.",
         rotationBackupGeneration: function(count) {
           return count + " sesi";
+        },
+        frontmatterSessionNotFound: function(n) {
+          return "Sesi \u201C" + n + "\u201D tidak ditemukan (workspace-session)";
+        },
+        frontmatterAlreadyActive: function(n) {
+          return "Sesi \u201C" + n + "\u201D sudah aktif";
         }
       }
     };
@@ -13445,6 +13529,102 @@ var require_history = __commonJS({
   }
 });
 
+// src/plugin/methods/frontmatter.js
+var require_frontmatter = __commonJS({
+  "src/plugin/methods/frontmatter.js"(exports2, module2) {
+    "use strict";
+    var obsidian2 = require("obsidian");
+    var i18n2 = require_i18n();
+    module2.exports = function attachFrontmatterMethods2(WorkspacePlusPlus2) {
+      WorkspacePlusPlus2.prototype.getFileFrontmatter = function(file) {
+        if (!file) return null;
+        var cache = this.app.metadataCache.getFileCache(file);
+        return cache && cache.frontmatter || null;
+      };
+      WorkspacePlusPlus2.prototype.parseWorkspaceSessionValue = function(value) {
+        if (!value || typeof value !== "string") return null;
+        value = value.trim();
+        if (!value) return null;
+        var slashIndex = value.indexOf("/");
+        if (slashIndex === -1) {
+          return { groupName: null, sessionName: value };
+        }
+        var candidateGroup = value.substring(0, slashIndex).trim();
+        var candidateSession = value.substring(slashIndex + 1).trim();
+        if (!candidateGroup || !candidateSession) {
+          return { groupName: null, sessionName: value };
+        }
+        var groups = this.data.groups || {};
+        var groupKeys = Object.keys(groups);
+        var matchedGroup = null;
+        for (var i = 0; i < groupKeys.length; i++) {
+          if (groups[groupKeys[i]].name === candidateGroup) {
+            matchedGroup = groups[groupKeys[i]];
+            break;
+          }
+        }
+        if (matchedGroup) {
+          return { groupName: candidateGroup, groupId: matchedGroup.id, sessionName: candidateSession };
+        }
+        return { groupName: null, sessionName: value };
+      };
+      WorkspacePlusPlus2.prototype.findSessionByName = function(name) {
+        if (!name) return null;
+        var sessions = this.data.sessions || {};
+        var keys = Object.keys(sessions);
+        for (var i = 0; i < keys.length; i++) {
+          if (sessions[keys[i]].name === name) {
+            return sessions[keys[i]];
+          }
+        }
+        return null;
+      };
+      WorkspacePlusPlus2.prototype.handleWorkspaceSessionProperty = function(value) {
+        var L = i18n2.L;
+        var parsed = this.parseWorkspaceSessionValue(value);
+        if (!parsed) return;
+        var session = this.findSessionByName(parsed.sessionName);
+        if (!session) {
+          new obsidian2.Notice(L.frontmatterSessionNotFound(parsed.sessionName));
+          return;
+        }
+        var alreadyOnSession = session.id === this.data.activeSessionId;
+        var alreadyOnGroup = !parsed.groupId || this.data.activeGroupId === parsed.groupId;
+        if (alreadyOnSession && alreadyOnGroup) {
+          new obsidian2.Notice(L.frontmatterAlreadyActive(parsed.sessionName));
+          return;
+        }
+        var self = this;
+        if (parsed.groupId && this.isGroupFeatureEnabled() && !alreadyOnGroup) {
+          this.setActiveGroup(parsed.groupId).then(function() {
+            if (session.id !== self.data.activeSessionId) {
+              self.switchSession(session.id);
+            }
+          });
+        } else if (!alreadyOnSession) {
+          this.switchSession(session.id);
+        }
+      };
+      WorkspacePlusPlus2.prototype.handleFrontmatterTriggers = function(file) {
+        var fm = this.getFileFrontmatter(file);
+        if (!fm) return;
+        if (fm["workspace-session"]) {
+          this.handleWorkspaceSessionProperty(fm["workspace-session"]);
+        }
+      };
+      WorkspacePlusPlus2.prototype.registerFrontmatterListeners = function() {
+        var self = this;
+        this.registerEvent(this.app.workspace.on("active-leaf-change", function(leaf) {
+          if (self.isSwitchingSession) return;
+          if (self.getStartupSettleRemainingMs() > 0) return;
+          if (!leaf || !leaf.view || !leaf.view.file) return;
+          self.handleFrontmatterTriggers(leaf.view.file);
+        }));
+      };
+    };
+  }
+});
+
 // src/main.js
 var obsidian = require("obsidian");
 var i18n = require_i18n();
@@ -13457,6 +13637,7 @@ var attachOverlayMethods = require_overlays();
 var attachPersistenceMethods = require_persistence();
 var attachSessionMethods = require_sessions();
 var attachHistoryMethods = require_history();
+var attachFrontmatterMethods = require_frontmatter();
 var utils = require_utils();
 var statusBarActions = require_statusbar_actions();
 i18n.resolveLocale();
@@ -13617,6 +13798,7 @@ var WorkspacePlusPlus = (
           self.scheduleStartupFlush();
           self.startHistorySnapshotTimer();
           self.initRotationBackupTimestamp();
+          self.registerFrontmatterListeners();
         });
       });
     };
@@ -13650,4 +13832,5 @@ attachOverlayMethods(WorkspacePlusPlus);
 attachPersistenceMethods(WorkspacePlusPlus);
 attachSessionMethods(WorkspacePlusPlus);
 attachHistoryMethods(WorkspacePlusPlus);
+attachFrontmatterMethods(WorkspacePlusPlus);
 module.exports = WorkspacePlusPlus;

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -381,6 +381,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: 'Failed to restore from backup.',
         rotationBackupNone: 'No backups available.',
         rotationBackupGeneration: function (count) { return count + ' session' + (count !== 1 ? 's' : ''); },
+        frontmatterSessionNotFound: function (n) { return 'Session "' + n + '" not found (workspace-session)'; },
+        frontmatterAlreadyActive: function (n) { return 'Session "' + n + '" is already active'; },
     },
     zh: {
         settingsStatusBarModScrollSwitch: '按住 Ctrl/Cmd 并滚动以切换会话',
@@ -612,6 +614,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: '从备份恢复失败。',
         rotationBackupNone: '没有可用的备份。',
         rotationBackupGeneration: function (count) { return count + ' 个会话'; },
+        frontmatterSessionNotFound: function (n) { return '\u4f1a\u8bdd\u201c' + n + '\u201d\u672a\u627e\u5230\uff08workspace-session\uff09'; },
+        frontmatterAlreadyActive: function (n) { return '\u4f1a\u8bdd\u201c' + n + '\u201d\u5df2\u5904\u4e8e\u6d3b\u52a8\u72b6\u6001'; },
     },
     'zh-TW': {
         settingsStatusBarModScrollSwitch: '按住 Ctrl/Cmd 並捲動以切換工作階段',
@@ -843,6 +847,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: '從備份還原失敗。',
         rotationBackupNone: '沒有可用的備份。',
         rotationBackupGeneration: function (count) { return count + ' 個工作階段'; },
+        frontmatterSessionNotFound: function (n) { return '\u5de5\u4f5c\u968e\u6bb5\u300c' + n + '\u300d\u672a\u627e\u5230\uff08workspace-session\uff09'; },
+        frontmatterAlreadyActive: function (n) { return '\u5de5\u4f5c\u968e\u6bb5\u300c' + n + '\u300d\u5df2\u8655\u65bc\u6d3b\u52d5\u72c0\u614b'; },
     },
     es: {
         settingsStatusBarModScrollSwitch: 'Mod + rueda para cambiar de sesión',
@@ -1074,6 +1080,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: 'Error al restaurar desde copia de seguridad.',
         rotationBackupNone: 'No hay copias de seguridad disponibles.',
         rotationBackupGeneration: function (count) { return count + ' sesión' + (count !== 1 ? 'es' : ''); },
+        frontmatterSessionNotFound: function (n) { return 'Sesi\u00f3n \u00ab' + n + '\u00bb no encontrada (workspace-session)'; },
+        frontmatterAlreadyActive: function (n) { return 'La sesi\u00f3n \u00ab' + n + '\u00bb ya est\u00e1 activa'; },
     },
     fr: {
         settingsStatusBarModScrollSwitch: 'Mod + molette pour changer de session',
@@ -1305,6 +1313,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: 'Échec de la restauration depuis la sauvegarde.',
         rotationBackupNone: 'Aucune sauvegarde disponible.',
         rotationBackupGeneration: function (count) { return count + ' session' + (count !== 1 ? 's' : ''); },
+        frontmatterSessionNotFound: function (n) { return 'Session \u00ab\u00a0' + n + '\u00a0\u00bb introuvable (workspace-session)'; },
+        frontmatterAlreadyActive: function (n) { return 'La session \u00ab\u00a0' + n + '\u00a0\u00bb est d\u00e9j\u00e0 active'; },
     },
     ar: {
         settingsStatusBarModScrollSwitch: 'استخدم Mod + التمرير للتبديل بين الجلسات',
@@ -1535,6 +1545,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: 'فشلت الاستعادة من النسخة الاحتياطية.',
         rotationBackupNone: 'لا توجد نسخ احتياطية متاحة.',
         rotationBackupGeneration: function (count) { return count + ' جلسة'; },
+        frontmatterSessionNotFound: function (n) { return '\u0627\u0644\u062c\u0644\u0633\u0629 \u201c' + n + '\u201d \u063a\u064a\u0631 \u0645\u0648\u062c\u0648\u062f\u0629 (workspace-session)'; },
+        frontmatterAlreadyActive: function (n) { return '\u0627\u0644\u062c\u0644\u0633\u0629 \u201c' + n + '\u201d \u0646\u0634\u0637\u0629 \u0628\u0627\u0644\u0641\u0639\u0644'; },
     },
     pt: {
         settingsStatusBarModScrollSwitch: 'Mod + rolagem para trocar de sessão',
@@ -1766,6 +1778,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: 'Falha ao restaurar a partir do backup.',
         rotationBackupNone: 'Nenhum backup disponível.',
         rotationBackupGeneration: function (count) { return count + ' sessão' + (count !== 1 ? 'ões' : ''); },
+        frontmatterSessionNotFound: function (n) { return 'Sess\u00e3o \u201c' + n + '\u201d n\u00e3o encontrada (workspace-session)'; },
+        frontmatterAlreadyActive: function (n) { return 'A sess\u00e3o \u201c' + n + '\u201d j\u00e1 est\u00e1 ativa'; },
     },
     ru: {
         settingsStatusBarModScrollSwitch: 'Mod + прокрутка для переключения сессий',
@@ -1996,6 +2010,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: 'Не удалось восстановить из резервной копии.',
         rotationBackupNone: 'Нет доступных резервных копий.',
         rotationBackupGeneration: function (count) { return count + ' сеанс' + (count === 1 ? '' : 'ов'); },
+        frontmatterSessionNotFound: function (n) { return '\u0421\u0435\u0430\u043d\u0441 \u00ab' + n + '\u00bb \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d (workspace-session)'; },
+        frontmatterAlreadyActive: function (n) { return '\u0421\u0435\u0430\u043d\u0441 \u00ab' + n + '\u00bb \u0443\u0436\u0435 \u0430\u043a\u0442\u0438\u0432\u0435\u043d'; },
     },
     de: {
         settingsStatusBarModScrollSwitch: 'Mit Mod + Scroll zwischen Sitzungen wechseln',
@@ -2226,6 +2242,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: 'Wiederherstellung aus Sicherung fehlgeschlagen.',
         rotationBackupNone: 'Keine Sicherungen verfügbar.',
         rotationBackupGeneration: function (count) { return count + ' Sitzung' + (count !== 1 ? 'en' : ''); },
+        frontmatterSessionNotFound: function (n) { return 'Sitzung \u201e' + n + '\u201c nicht gefunden (workspace-session)'; },
+        frontmatterAlreadyActive: function (n) { return 'Sitzung \u201e' + n + '\u201c ist bereits aktiv'; },
     },
     ja: {
         modalTitle: 'セッション管理',
@@ -2567,6 +2585,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: 'バックアップからの復元に失敗しました。',
         rotationBackupNone: 'バックアップはありません。',
         rotationBackupGeneration: function (count) { return count + ' セッション'; },
+        frontmatterSessionNotFound: function (n) { return 'セッション「' + n + '」が見つかりません（workspace-session）'; },
+        frontmatterAlreadyActive: function (n) { return 'セッション「' + n + '」は既にアクティブです'; },
     },
     ko: {
         settingsStatusBarModScrollSwitch: 'Mod + 스크롤로 세션 전환',
@@ -2798,6 +2818,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: '백업에서 복원하지 못했습니다.',
         rotationBackupNone: '사용 가능한 백업이 없습니다.',
         rotationBackupGeneration: function (count) { return count + '개 세션'; },
+        frontmatterSessionNotFound: function (n) { return '\u201c' + n + '\u201d \uc138\uc158\uc744 \ucc3e\uc744 \uc218 \uc5c6\uc2b5\ub2c8\ub2e4 (workspace-session)'; },
+        frontmatterAlreadyActive: function (n) { return '\u201c' + n + '\u201d \uc138\uc158\uc774 \uc774\ubbf8 \ud65c\uc131 \uc0c1\ud0dc\uc785\ub2c8\ub2e4'; },
     },
     it: {
         settingsStatusBarModScrollSwitch: 'Mod + rotellina per cambiare sessione',
@@ -3029,6 +3051,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: 'Ripristino dal backup non riuscito.',
         rotationBackupNone: 'Nessun backup disponibile.',
         rotationBackupGeneration: function (count) { return count + ' session' + (count !== 1 ? 'i' : 'e'); },
+        frontmatterSessionNotFound: function (n) { return 'Sessione \u00ab' + n + '\u00bb non trovata (workspace-session)'; },
+        frontmatterAlreadyActive: function (n) { return 'La sessione \u00ab' + n + '\u00bb \u00e8 gi\u00e0 attiva'; },
     },
     tr: {
         settingsStatusBarModScrollSwitch: 'Mod + kaydırma ile oturum değiştir',
@@ -3259,6 +3283,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: 'Yedekten geri yükleme başarısız.',
         rotationBackupNone: 'Kullanılabilir yedek yok.',
         rotationBackupGeneration: function (count) { return count + ' oturum'; },
+        frontmatterSessionNotFound: function (n) { return '\u201c' + n + '\u201d oturumu bulunamad\u0131 (workspace-session)'; },
+        frontmatterAlreadyActive: function (n) { return '\u201c' + n + '\u201d oturumu zaten aktif'; },
     },
     id: {
         settingsStatusBarModScrollSwitch: 'Mod + gulir untuk berpindah sesi',
@@ -3490,6 +3516,8 @@ var STRINGS = {
         rotationBackupRestoreFailed: 'Gagal memulihkan dari cadangan.',
         rotationBackupNone: 'Tidak ada cadangan tersedia.',
         rotationBackupGeneration: function (count) { return count + ' sesi'; },
+        frontmatterSessionNotFound: function (n) { return 'Sesi \u201c' + n + '\u201d tidak ditemukan (workspace-session)'; },
+        frontmatterAlreadyActive: function (n) { return 'Sesi \u201c' + n + '\u201d sudah aktif'; },
     },
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ var attachOverlayMethods = require('./plugin/methods/overlays');
 var attachPersistenceMethods = require('./plugin/methods/persistence');
 var attachSessionMethods = require('./plugin/methods/sessions');
 var attachHistoryMethods = require('./plugin/methods/history');
+var attachFrontmatterMethods = require('./plugin/methods/frontmatter');
 var utils = require('./utils');
 var statusBarActions = require('./statusbar-actions');
 
@@ -200,6 +201,7 @@ var WorkspacePlusPlus = /** @class */ (function (_super) {
                 self.scheduleStartupFlush();
                 self.startHistorySnapshotTimer();
                 self.initRotationBackupTimestamp();
+                self.registerFrontmatterListeners();
             });
         });
     };
@@ -235,5 +237,6 @@ attachOverlayMethods(WorkspacePlusPlus);
 attachPersistenceMethods(WorkspacePlusPlus);
 attachSessionMethods(WorkspacePlusPlus);
 attachHistoryMethods(WorkspacePlusPlus);
+attachFrontmatterMethods(WorkspacePlusPlus);
 
 module.exports = WorkspacePlusPlus;

--- a/src/plugin/methods/frontmatter.js
+++ b/src/plugin/methods/frontmatter.js
@@ -1,0 +1,172 @@
+'use strict';
+
+var obsidian = require('obsidian');
+var i18n = require('../../i18n');
+
+// ============================================================
+// Front-matter integration
+//
+// Watches for file-open events and reads front-matter properties
+// to trigger plugin actions (e.g. auto-loading a session).
+// ============================================================
+
+module.exports = function attachFrontmatterMethods(WorkspacePlusPlus) {
+
+    // ----------------------------------------------------------
+    // Core: read front-matter from the active file
+    // ----------------------------------------------------------
+
+    /**
+     * Returns the front-matter object for the given TFile, or null.
+     */
+    WorkspacePlusPlus.prototype.getFileFrontmatter = function (file) {
+        if (!file) return null;
+        var cache = this.app.metadataCache.getFileCache(file);
+        return (cache && cache.frontmatter) || null;
+    };
+
+    // ----------------------------------------------------------
+    // workspace-session property
+    // ----------------------------------------------------------
+
+    /**
+     * Parse a workspace-session value into { groupName, sessionName }.
+     *
+     * "my session"          → { groupName: null, sessionName: "my session" }
+     * "work/my session"     → first checks if group "work" exists;
+     *                          if yes → { groupName: "work", sessionName: "my session" }
+     *                          if no  → { groupName: null, sessionName: "work/my session" }
+     */
+    WorkspacePlusPlus.prototype.parseWorkspaceSessionValue = function (value) {
+        if (!value || typeof value !== 'string') return null;
+        value = value.trim();
+        if (!value) return null;
+
+        var slashIndex = value.indexOf('/');
+        if (slashIndex === -1) {
+            return { groupName: null, sessionName: value };
+        }
+
+        var candidateGroup = value.substring(0, slashIndex).trim();
+        var candidateSession = value.substring(slashIndex + 1).trim();
+
+        if (!candidateGroup || !candidateSession) {
+            return { groupName: null, sessionName: value };
+        }
+
+        // Check if a group with this name actually exists
+        var groups = this.data.groups || {};
+        var groupKeys = Object.keys(groups);
+        var matchedGroup = null;
+        for (var i = 0; i < groupKeys.length; i++) {
+            if (groups[groupKeys[i]].name === candidateGroup) {
+                matchedGroup = groups[groupKeys[i]];
+                break;
+            }
+        }
+
+        if (matchedGroup) {
+            return { groupName: candidateGroup, groupId: matchedGroup.id, sessionName: candidateSession };
+        }
+
+        // No matching group — treat entire value as session name
+        return { groupName: null, sessionName: value };
+    };
+
+    /**
+     * Find a session by name. Returns the session object or null.
+     */
+    WorkspacePlusPlus.prototype.findSessionByName = function (name) {
+        if (!name) return null;
+        var sessions = this.data.sessions || {};
+        var keys = Object.keys(sessions);
+        for (var i = 0; i < keys.length; i++) {
+            if (sessions[keys[i]].name === name) {
+                return sessions[keys[i]];
+            }
+        }
+        return null;
+    };
+
+    /**
+     * Handle the workspace-session front-matter property.
+     * Switches to the named session (and optionally the group).
+     */
+    WorkspacePlusPlus.prototype.handleWorkspaceSessionProperty = function (value) {
+        var L = i18n.L;
+        var parsed = this.parseWorkspaceSessionValue(value);
+        if (!parsed) return;
+
+        var session = this.findSessionByName(parsed.sessionName);
+        if (!session) {
+            new obsidian.Notice(L.frontmatterSessionNotFound(parsed.sessionName));
+            return;
+        }
+
+        var alreadyOnSession = session.id === this.data.activeSessionId;
+        var alreadyOnGroup = !parsed.groupId || this.data.activeGroupId === parsed.groupId;
+
+        // Already on the correct session and group — notify and skip
+        if (alreadyOnSession && alreadyOnGroup) {
+            new obsidian.Notice(L.frontmatterAlreadyActive(parsed.sessionName));
+            return;
+        }
+
+        var self = this;
+
+        // If a group was specified and group feature is enabled, switch group
+        if (parsed.groupId && this.isGroupFeatureEnabled() && !alreadyOnGroup) {
+            this.setActiveGroup(parsed.groupId).then(function () {
+                if (session.id !== self.data.activeSessionId) {
+                    self.switchSession(session.id);
+                }
+            });
+        } else if (!alreadyOnSession) {
+            this.switchSession(session.id);
+        }
+    };
+
+    // ----------------------------------------------------------
+    // Dispatcher: called on active-leaf-change
+    // ----------------------------------------------------------
+
+    /**
+     * Central dispatcher that reads front-matter from the active file
+     * and delegates to the appropriate handler(s).
+     *
+     * New front-matter keys can be added here in the future.
+     */
+    WorkspacePlusPlus.prototype.handleFrontmatterTriggers = function (file) {
+        var fm = this.getFileFrontmatter(file);
+        if (!fm) return;
+
+        // workspace-session
+        if (fm['workspace-session']) {
+            this.handleWorkspaceSessionProperty(fm['workspace-session']);
+        }
+
+        // Future front-matter keys can be handled here:
+        // if (fm['workspace-xxx']) { ... }
+    };
+
+    // ----------------------------------------------------------
+    // Event registration
+    // ----------------------------------------------------------
+
+    /**
+     * Register the active-leaf-change listener.
+     * Should be called once during plugin onload().
+     */
+    WorkspacePlusPlus.prototype.registerFrontmatterListeners = function () {
+        var self = this;
+
+        this.registerEvent(this.app.workspace.on('active-leaf-change', function (leaf) {
+            // Guard: don't trigger during session switch or startup settle
+            if (self.isSwitchingSession) return;
+            if (self.getStartupSettleRemainingMs() > 0) return;
+
+            if (!leaf || !leaf.view || !leaf.view.file) return;
+            self.handleFrontmatterTriggers(leaf.view.file);
+        }));
+    };
+};


### PR DESCRIPTION
## Summary
- Add `workspace-session` front-matter property to auto-load sessions when opening a note
- Support `group/session` format (e.g. `"work/my session"`) with automatic group name detection
- Show notices for missing sessions and already-active sessions
- i18n translations for all 14 languages

Closes #87

## Usage

```yaml
---
workspace-session: "my session"
---
```

Or with group:

```yaml
---
workspace-session: "group name/session name"
---
```

## Test plan
- [ ] Open a note with `workspace-session` in front-matter → session switches
- [ ] Open a note with `group/session` format → group and session switch
- [ ] Open a note with non-existent session name → notice shown
- [ ] Open a note when already on the specified session → "already active" notice
- [ ] Session switch during startup settle → no trigger
- [ ] Session name containing `/` with no matching group → treated as full session name

🤖 Generated with [Claude Code](https://claude.com/claude-code)