### PR TITLE
fix: keep session cycling responsive under rapid keypresses

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -45,6 +45,7 @@ var WorkspacePlusPlus = /** @class */ (function (_super) {
             self.normalizeGroupFeatureState();
             self.isSwitchingSession = false;
             self.pendingSwitchRequest = null;
+            self.pendingSwitchTargetId = null;
             self.switchLockAt = 0;
             self.startupSettleStartedAt = 0;
             self.startupSettleUntil = 0;
@@ -104,6 +105,7 @@ var WorkspacePlusPlus = /** @class */ (function (_super) {
         this.hideSearchOverlay();
         this.clearSessionSwitchNotice();
         this.pendingSwitchRequest = null;
+        this.pendingSwitchTargetId = null;
         this.isSwitchingSession = false;
         this.statusBarScrollDelta = 0;
         this.statusBarScrollEventAt = 0;

--- a/src/plugin/methods/session-switching.js
+++ b/src/plugin/methods/session-switching.js
@@ -36,6 +36,14 @@ function attachSessionSwitchingMethods(WorkspacePlusPlus) {
         return notice;
     };
 
+    // Where relative navigation counts from. While a switch is still applying
+    // its layout, data.activeSessionId lags behind the session the user has
+    // already asked for, so stepping from it makes every press during the
+    // switch resolve to the same target and collapse into a single step.
+    WorkspacePlusPlus.prototype.getRelativeSwitchBaseId = function () {
+        return this.pendingSwitchTargetId || this.data.activeSessionId;
+    };
+
     WorkspacePlusPlus.prototype.getRelativeSwitchContext = function (offset) {
         var ordered = this.getOrderedSessions();
         if (ordered.length === 0) {
@@ -46,8 +54,20 @@ function attachSessionSwitchingMethods(WorkspacePlusPlus) {
                 isEmpty: true,
             };
         }
-        var currentIndex = this.findActiveSessionIndex(ordered);
-        if (currentIndex === -1) return null;
+
+        var currentIndex = this.findSessionIndex(ordered, this.getRelativeSwitchBaseId());
+        if (currentIndex === -1) {
+            // The active session is not in the current view - it was removed
+            // from the active group, moved elsewhere, or the view is showing a
+            // different group. Enter the list from the near edge rather than
+            // going inert.
+            return {
+                ordered: ordered,
+                currentIndex: -1,
+                targetIndex: offset > 0 ? 0 : ordered.length - 1,
+                isEmpty: false,
+            };
+        }
 
         return {
             ordered: ordered,
@@ -73,7 +93,7 @@ function attachSessionSwitchingMethods(WorkspacePlusPlus) {
             return Promise.resolve(false);
         }
 
-        if (ordered[index].id === this.data.activeSessionId) {
+        if (ordered[index].id === this.getRelativeSwitchBaseId()) {
             if (options.noticeMode === 'replace') {
                 this.showSessionSwitchNotice(ordered[index].name, {
                     durationMs: options.switchNoticeDurationMs,
@@ -188,11 +208,22 @@ function attachSessionSwitchingMethods(WorkspacePlusPlus) {
             .then(function () {
                 self.isSwitchingSession = false;
                 self.switchLockAt = 0;
-                if (!self.pendingSwitchRequest) return;
+                if (!self.pendingSwitchRequest) {
+                    self.pendingSwitchTargetId = null;
+                    return;
+                }
                 var next = self.pendingSwitchRequest;
                 self.pendingSwitchRequest = null;
                 self.runSwitchRequest(next);
             });
+    };
+
+    // A confirm dialog or the switch overlay means the user is mid-interaction,
+    // so a switch that looks stuck is probably just waiting on them.
+    WorkspacePlusPlus.prototype.hasBlockingSwitchUi = function () {
+        if (typeof document === 'undefined') return false;
+        return !!document.querySelector('.wpp-confirm-buttons')
+            || !!document.querySelector('.wpp-switch-overlay');
     };
 
     WorkspacePlusPlus.prototype.switchSession = function (targetId, options) {
@@ -212,11 +243,11 @@ function attachSessionSwitchingMethods(WorkspacePlusPlus) {
         if (this.isSwitchingSession) {
             var lockAt = this.switchLockAt || 0;
             var elapsed = lockAt ? (Date.now() - lockAt) : Number.MAX_SAFE_INTEGER;
-            var hasBlockingUi = !!document.querySelector('.wpp-confirm-buttons')
-                || !!document.querySelector('.wpp-switch-overlay');
+            var hasBlockingUi = this.hasBlockingSwitchUi();
             if (!hasBlockingUi && elapsed > 5000) {
                 this.isSwitchingSession = false;
                 this.switchLockAt = 0;
+                this.pendingSwitchTargetId = null;
                 if (this.pendingSwitchRequest) {
                     this.pendingSwitchRequest.resolve(false);
                     this.pendingSwitchRequest = null;
@@ -229,6 +260,10 @@ function attachSessionSwitchingMethods(WorkspacePlusPlus) {
             return Promise.resolve(false);
         }
 
+        // Remember where the user has asked to end up, so relative navigation
+        // keeps stepping forward while this switch is still applying.
+        this.pendingSwitchTargetId = targetId;
+
         return new Promise(function (resolve) {
             var request = {
                 targetId: targetId,
@@ -237,6 +272,8 @@ function attachSessionSwitchingMethods(WorkspacePlusPlus) {
             };
 
             if (self.isSwitchingSession) {
+                // Superseding the queued request is intentional: its target was
+                // an intermediate stop, and the new one already accounts for it.
                 if (self.pendingSwitchRequest) {
                     self.pendingSwitchRequest.resolve(false);
                 }

--- a/tests/session-switching.test.js
+++ b/tests/session-switching.test.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('module');
+
+const i18n = require('../src/i18n');
+
+i18n.resolveLocale('en');
+
+function loadSessionSwitchingMethods() {
+    const obsidianStub = {
+        Modal: class {},
+        Notice: class {
+            constructor(_message) {}
+            hide() {}
+        },
+        setIcon: function () {},
+        setTooltip: function () {},
+    };
+    const originalLoad = Module._load;
+    Module._load = function (request, parent, isMain) {
+        if (request === 'obsidian') return obsidianStub;
+        return originalLoad(request, parent, isMain);
+    };
+
+    try {
+        return require('../src/plugin/methods/session-switching');
+    } finally {
+        Module._load = originalLoad;
+    }
+}
+
+const attachSessionSwitchingMethods = loadSessionSwitchingMethods();
+const attachSessionMethods = require('../src/plugin/methods/sessions');
+
+// A plugin whose layout application is deliberately slow, so a switch is still
+// in flight while the next keypress arrives.
+function createPlugin(options) {
+    options = options || {};
+
+    function PluginMock() {}
+    attachSessionMethods(PluginMock);
+    attachSessionSwitchingMethods(PluginMock);
+
+    const plugin = new PluginMock();
+    const names = options.names || ['a', 'b', 'c', 'd'];
+    const sessions = {};
+    const sessionOrder = [];
+    for (const name of names) {
+        sessions[name] = { id: name, name: name, layout: { root: name } };
+        sessionOrder.push(name);
+    }
+
+    plugin.data = {
+        sessions: sessions,
+        sessionOrder: sessionOrder,
+        activeSessionId: options.activeSessionId || names[0],
+        groupFeatureEnabled: false,
+        activeGroupId: null,
+        previewNext: false,
+        previewPrevious: false,
+    };
+
+    plugin.isSwitchingSession = false;
+    plugin.pendingSwitchRequest = null;
+    plugin.pendingSwitchTargetId = null;
+    plugin.switchLockAt = 0;
+
+    plugin.appliedLayouts = [];
+    plugin.pendingLayoutResolvers = [];
+
+    plugin.isGroupFeatureEnabled = function () { return false; };
+    plugin.getStartupSettleRemainingMs = function () { return 0; };
+    plugin.isAutoSaveOnSwitchEnabled = function () { return false; };
+    plugin.isWarnOnUnsavedSwitchEnabled = function () { return false; };
+    plugin.isActiveSessionDirty = function () { return false; };
+    plugin.pushLayoutToHistory = function () {};
+    plugin.getCurrentWorkspaceLayout = function () { return { root: 'current' }; };
+    plugin.updateStatusBar = function () {};
+    plugin.persistData = function () { return Promise.resolve(); };
+    plugin.showSwitchPreviewOverlay = function (ordered, index) {
+        plugin.overlayIndexes.push(index);
+    };
+    plugin.overlayIndexes = [];
+
+    // Hold every layout application open until the test releases it.
+    plugin.applyWorkspaceLayout = function (layout) {
+        plugin.appliedLayouts.push(layout);
+        return new Promise(function (resolve) {
+            plugin.pendingLayoutResolvers.push(resolve);
+        });
+    };
+
+    plugin.releaseLayouts = function () {
+        const resolvers = plugin.pendingLayoutResolvers;
+        plugin.pendingLayoutResolvers = [];
+        for (const resolve of resolvers) resolve();
+        // Let the promise chain in runSwitchRequest settle.
+        return new Promise(function (resolve) { setImmediate(resolve); });
+    };
+
+    return plugin;
+}
+
+test('rapid relative switches accumulate instead of collapsing onto one target', async () => {
+    const plugin = createPlugin();
+
+    // Press 1: starts a switch a -> b, layout still applying.
+    plugin.switchRelativeFromCommand(1);
+    assert.equal(plugin.data.activeSessionId, 'b');
+    assert.equal(plugin.pendingSwitchTargetId, 'b');
+
+    // Presses 2 and 3 land while that switch is in flight. Each must step
+    // forward from the last requested target, not from the applied one.
+    plugin.switchRelativeFromCommand(1);
+    assert.equal(plugin.pendingSwitchTargetId, 'c');
+    plugin.switchRelativeFromCommand(1);
+    assert.equal(plugin.pendingSwitchTargetId, 'd');
+
+    await plugin.releaseLayouts();
+    await plugin.releaseLayouts();
+
+    assert.equal(plugin.data.activeSessionId, 'd', 'three presses should advance three sessions');
+    assert.equal(plugin.pendingSwitchTargetId, null, 'the pending target is released once the queue drains');
+});
+
+test('the overlay highlight follows every press, not just the applied switch', async () => {
+    const plugin = createPlugin();
+
+    plugin.switchRelativeFromCommand(1);
+    plugin.switchRelativeFromCommand(1);
+    plugin.switchRelativeFromCommand(1);
+
+    assert.deepEqual(plugin.overlayIndexes, [1, 2, 3]);
+
+    await plugin.releaseLayouts();
+    await plugin.releaseLayouts();
+});
+
+test('relative switching wraps around from the last session', async () => {
+    const plugin = createPlugin({ activeSessionId: 'd' });
+
+    plugin.switchRelativeFromCommand(1);
+    assert.equal(plugin.data.activeSessionId, 'a');
+
+    await plugin.releaseLayouts();
+});
+
+test('switching stays responsive when the active session is not in the current view', async () => {
+    const plugin = createPlugin();
+    // Simulates the active session having been removed from the active group:
+    // it is no longer part of the ordered list the command navigates.
+    plugin.getOrderedSessions = function () {
+        return ['b', 'c', 'd'].map(function (id) { return plugin.data.sessions[id]; });
+    };
+
+    const context = plugin.getRelativeSwitchContext(1);
+    assert.notEqual(context, null, 'a missing active session must not make the command inert');
+    assert.equal(context.currentIndex, -1);
+    assert.equal(context.targetIndex, 0, 'next enters the list at the first session');
+
+    assert.equal(plugin.getRelativeSwitchContext(-1).targetIndex, 2, 'previous enters at the last session');
+
+    plugin.switchRelativeFromCommand(1);
+    assert.equal(plugin.data.activeSessionId, 'b');
+
+    await plugin.releaseLayouts();
+});
+
+test('a stale switch lock releases the remembered target', async () => {
+    const plugin = createPlugin();
+    plugin.switchRelativeFromCommand(1);
+    assert.equal(plugin.pendingSwitchTargetId, 'b');
+
+    // No overlay or modal on screen and the lock is older than the 5s grace.
+    plugin.switchLockAt = Date.now() - 10000;
+    plugin.switchSession('d', {});
+
+    assert.equal(plugin.pendingSwitchTargetId, 'd');
+    await plugin.releaseLayouts();
+});


### PR DESCRIPTION
Fixes both stalls described in #107.

### Rapid presses collapsed onto one target

Relative navigation stepped from `data.activeSessionId`, which does not advance until an in-flight switch has applied its layout. Every press during that window resolved to the *same* target and overwrote the single queued request, so N presses produced one step.

Navigation now steps from the last **requested** target (`pendingSwitchTargetId`), so presses accumulate and the overlay highlight follows each one. Superseding the queued request remains correct — the newer target already accounts for the one it replaces.

### Inert switching when the active session left the view

`getRelativeSwitchContext` returned `null` when the active session was not in the ordered list, so the command silently did nothing, while the overlay highlighted the first session because `getSessionIndex` falls back to `0`. It now enters the list from the near edge (first for next, last for previous).

### Tests

New `tests/session-switching.test.js` (5 tests), verified to fail without each fix:

- reverting the base-id change fails the two accumulation tests
- reverting the `-1` handling fails the missing-active-session test

Also extracts the stale-lock DOM probe into `hasBlockingSwitchUi()`, guarded for a missing `document`, so the module is testable without a DOM stub.

127 tests pass.

Fixes #107